### PR TITLE
Set unique name in client so HttpContext.User.Identity.Name is set

### DIFF
--- a/src/WebMotions.Fake.Authentication.JwtBearer/HttpClientExtensions.cs
+++ b/src/WebMotions.Fake.Authentication.JwtBearer/HttpClientExtensions.cs
@@ -33,7 +33,8 @@ namespace System.Net
         {
             client.SetFakeBearerToken(new
             {
-                sub = username
+                sub = username,
+                unique_name = username
             });
 
             return client;
@@ -52,6 +53,7 @@ namespace System.Net
             client.SetFakeBearerToken(new
             {
                 sub = username,
+                unique_name = username,
                 role = roles
             });
 
@@ -69,6 +71,7 @@ namespace System.Net
         public static HttpClient SetFakeBearerToken(this HttpClient client, string username, string[] roles, dynamic claim)
         {
             claim.sub = username;
+            claim.unique_name = username;
             claim.role = roles;
 
             client.SetFakeBearerToken((object) claim);


### PR DESCRIPTION
Without setting unique_name in the token the web project doesn't set the user identity name, so just adding this in so it works :)