### PR TITLE
Add support for JWT tokens.

### DIFF
--- a/src/WebMotions.Fake.Authentication.JwtBearer/FakeJwtBearerBearerValueType.cs
+++ b/src/WebMotions.Fake.Authentication.JwtBearer/FakeJwtBearerBearerValueType.cs
@@ -12,6 +12,10 @@
         /// <summary>
         /// Token in Base64 Format
         /// </summary>
-        Base64
+        Base64,
+        /// <summary>
+        /// Token is a JWT
+        /// </summary>
+        Jwt
     }
 }

--- a/src/WebMotions.Fake.Authentication.JwtBearer/FakeJwtBearerClaimsHandler.cs
+++ b/src/WebMotions.Fake.Authentication.JwtBearer/FakeJwtBearerClaimsHandler.cs
@@ -84,6 +84,25 @@ namespace WebMotions.Fake.Authentication.JwtBearer
 
             return identity;
         }
+        
+        /// <summary>
+        /// Creates a claims identity from a JWT token
+        /// </summary>
+        /// <param name="jwtToken">The JWT token</param>
+        /// <returns>A <see cref="ClaimsIdentity"/></returns>
+        public virtual ClaimsIdentity CreateClaimsIdentity(string jwtToken)
+        {
+            var identity = new ClaimsIdentity("FakeJwtBearer");
+            var tokenHandler = new JwtSecurityTokenHandler();
+            if (tokenHandler.ReadToken(jwtToken) is not JwtSecurityToken securityToken) return identity;
+            foreach (var claim in securityToken.Claims)
+            {
+                identity.AddClaim(claim);
+            }
+
+            return identity;
+        }
+        
 
         private Claim CreateClaim(string key, string value, ClaimsIdentity identity, string issuer, string originalIssuer)
         {

--- a/src/WebMotions.Fake.Authentication.JwtBearer/FakeJwtBearerHandler.cs
+++ b/src/WebMotions.Fake.Authentication.JwtBearer/FakeJwtBearerHandler.cs
@@ -81,20 +81,26 @@ namespace WebMotions.Fake.Authentication.JwtBearer
                 }
 
                 Dictionary<string, JsonElement> tokenDecoded;
-                if (Options.BearerValueType == FakeJwtBearerBearerValueType.Base64)
-                {
-                    var tokenFromBase64 = Convert.FromBase64String(token);
-                    tokenDecoded = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(Encoding.UTF8.GetString(tokenFromBase64));
-                }
-                else
-                {
-                    tokenDecoded = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(token);
-                }
-
-                Logger.TokenValidationSucceeded();
-
+                ClaimsIdentity id;
                 var claimsHandler = Options.SecurityTokenClaimHandler;
-                ClaimsIdentity id = claimsHandler.CreateClaimsIdentity(tokenDecoded);
+
+                switch (Options.BearerValueType)
+                {
+                    case FakeJwtBearerBearerValueType.Base64:
+                        var tokenFromBase64 = Convert.FromBase64String(token);
+                        tokenDecoded = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(Encoding.UTF8.GetString(tokenFromBase64));
+                        id = claimsHandler.CreateClaimsIdentity(tokenDecoded);
+                        break;
+                    case FakeJwtBearerBearerValueType.Jwt:
+                        id = claimsHandler.CreateClaimsIdentity(token);
+                        break;
+                    default:
+                        tokenDecoded = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(token);
+                        id = claimsHandler.CreateClaimsIdentity(tokenDecoded);
+                        break;
+                }
+                
+                Logger.TokenValidationSucceeded();
 
                 ClaimsPrincipal principal = new ClaimsPrincipal(id);
 

--- a/src/WebMotions.Fake.Authentication.JwtBearer/HttpClientExtensions.cs
+++ b/src/WebMotions.Fake.Authentication.JwtBearer/HttpClientExtensions.cs
@@ -5,6 +5,7 @@ using System.Net.Http.Headers;
 using System.Security.Claims;
 using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
+using WebMotions.Fake.Authentication.JwtBearer;
 
 // ReSharper disable once CheckNamespace
 namespace System.Net
@@ -22,7 +23,7 @@ namespace System.Net
         /// <returns></returns>
         public static HttpClient SetFakeBearerToken(this HttpClient client, object token)
         {
-            client.SetToken("FakeBearer", JsonConvert.SerializeObject(token));
+            client.SetToken(FakeJwtBearerDefaults.AuthenticationScheme, JsonConvert.SerializeObject(token));
 
             return client;
         }
@@ -101,7 +102,7 @@ namespace System.Net
 
             var token = tokenHandler.CreateToken(tokenDescriptor);
             var jwt = tokenHandler.WriteToken(token);
-            return client.SetToken("FakeBearer", jwt);
+            return client.SetToken(FakeJwtBearerDefaults.AuthenticationScheme, jwt);
         }
 
         /// <summary>

--- a/src/WebMotions.Fake.Authentication.JwtBearer/HttpClientExtensions.cs
+++ b/src/WebMotions.Fake.Authentication.JwtBearer/HttpClientExtensions.cs
@@ -1,5 +1,9 @@
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Security.Claims;
+using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
 
 // ReSharper disable once CheckNamespace
@@ -77,6 +81,27 @@ namespace System.Net
             client.SetFakeBearerToken((object) claim);
 
             return client;
+        }
+        
+        /// <summary>
+        /// Set a fake bearer token in form of a JWT. 
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="claims"></param>
+        /// <returns></returns>
+        public static HttpClient SetFakeJwtBearerToken(this HttpClient client, Dictionary<string, object> claims)
+        {
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var tokenDescriptor = new SecurityTokenDescriptor
+            {
+                Subject = new ClaimsIdentity(),
+                Expires = DateTime.UtcNow.AddDays(7),
+                Claims = claims
+            };
+
+            var token = tokenHandler.CreateToken(tokenDescriptor);
+            var jwt = tokenHandler.WriteToken(token);
+            return client.SetToken("FakeBearer", jwt);
         }
 
         /// <summary>

--- a/src/WebMotions.Fake.Authentication.JwtBearer/ISecurityTokenClaimsHandler.cs
+++ b/src/WebMotions.Fake.Authentication.JwtBearer/ISecurityTokenClaimsHandler.cs
@@ -15,5 +15,12 @@ namespace WebMotions.Fake.Authentication.JwtBearer
         /// <param name="token">The token data</param>
         /// <returns>A <see cref="ClaimsIdentity"/></returns>
         ClaimsIdentity CreateClaimsIdentity(Dictionary<string, JsonElement> token);
+        
+        /// <summary>
+        /// Creates a claims identity from a JWT token
+        /// </summary>
+        /// <param name="jwtToken">The JWT token</param>
+        /// <returns>A <see cref="ClaimsIdentity"/></returns>
+        ClaimsIdentity CreateClaimsIdentity(string jwtToken);
     }
 }


### PR DESCRIPTION
Was creating integration tests for a project where we are using authentication using JWT security tokens. The project worked well until code inside the project tried to get the token and interrogate it for claims. Since the token was not really a JWT it caused an exception. We like to fake as little code as possible so I did not want to fake the JWT reading code.

Instead I built on top of what you have to add a couple small tweaks to support simple JWT creation. It's working for me locally but I'd love to just use the NuGet and contribute this back to you to do that.

Let me know if you have any feedback or need any further changes.