### PR TITLE
Fix role not working - incorrect claim type

### DIFF
--- a/src/WebMotions.Fake.Authentication.JwtBearer/HttpClientExtensions.cs
+++ b/src/WebMotions.Fake.Authentication.JwtBearer/HttpClientExtensions.cs
@@ -58,7 +58,7 @@ namespace System.Net
             {
                 sub = username,
                 unique_name = username,
-                role = roles
+                roles = roles
             });
 
             return client;
@@ -76,7 +76,7 @@ namespace System.Net
         {
             claim.sub = username;
             claim.unique_name = username;
-            claim.role = roles;
+            claim.roles = roles;
 
             client.SetFakeBearerToken((object)claim);
 


### PR DESCRIPTION
I'm not sure if this is some difference using a newer version of asp.net core but the claim type "role" doesn't exist so it doesn't get mapped, it should be "roles".